### PR TITLE
fixed prop hp label not reseting properly

### DIFF
--- a/Scenes/Main.tscn
+++ b/Scenes/Main.tscn
@@ -83,7 +83,7 @@ size_flags_vertical = 3
 [node name="IPaddr" type="LineEdit" parent="Menu/VBoxContainer/HBoxContainer/VBoxContainer2"]
 margin_right = 325.0
 margin_bottom = 24.0
-text = "25.102.221.68"
+text = "localhost"
 
 [node name="port" type="LineEdit" parent="Menu/VBoxContainer/HBoxContainer/VBoxContainer2"]
 margin_top = 28.0

--- a/Scenes/player_Prop.tscn
+++ b/Scenes/player_Prop.tscn
@@ -28,6 +28,7 @@ points = PoolVector3Array( 1.15839e-08, 0.649358, -0.088236, 1.15839e-08, 0.6493
 ]]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0 )
 script = ExtResource( 3 )
+maxHp = 12
 
 [node name="Body" type="Spatial" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.0465, 0 )

--- a/project.godot
+++ b/project.godot
@@ -24,7 +24,7 @@ Lobby="*res://scripts/Lobby.gd"
 
 [debug]
 
-multirun/number_of_windows=2
+multirun/number_of_windows=1
 multirun/window_distance=1270
 multirun/add_custom_args=true
 multirun/other_window_args="join"

--- a/scripts/player_Hunter.gd
+++ b/scripts/player_Hunter.gd
@@ -22,14 +22,15 @@ onready var HUD_HP = $CameraOrbit/Camera/HUD/HPIndicator
 func _ready():
 	if is_network_master():
 		HUD_role.text = "HUNTER"
-		HUD_HP.text = "HP: " + str(curHp)
+		HUD_HP.text = "HUNTER HP: " + str(curHp)
 
 
 remote func takeDamage(damage):
 	curHp -= damage
-	HUD_HP.text = "HP: " + str(curHp)
+	HUD_HP.text = "HUNTER HP: " + str(curHp)
+	print("hurting hunter")
 	if curHp < 1:
-		print("YOU DIED")
+		print("HUNTER : YOU DIED")
 
 
 func _unhandled_input(event):
@@ -50,7 +51,7 @@ func _unhandled_input(event):
 			var thingInFront = attackRayCast.get_collider()
 			if thingInFront:
 				if thingInFront.is_in_group("player_prop"):
-					rpc_id(int(thingInFront.name),"takeDamage",myDamage)
+					thingInFront.takeDamageProp(myDamage,int(thingInFront.name))
 				elif thingInFront.is_in_group("prop"):
 					takeDamage(myDamage)
 				else:

--- a/scripts/player_Prop.gd
+++ b/scripts/player_Prop.gd
@@ -22,14 +22,19 @@ onready var body = $Body
 func _ready():
 	if is_network_master():
 		HUD_role.text = "PROP"
-		HUD_HP.text = "HP: " + str(curHp)
+		HUD_HP.text = "PROP HP: " + str(curHp)
+		print("setting hp first time for prop")
 
-
-remote func takeDamage(damage):
+remote func takeDamagePropRpc(damage):
 	curHp -= damage
-	HUD_HP.text = "HP: " + str(curHp)
+	HUD_HP.text = "PROP HP: " + str(curHp)
+	print("setting hp second time for prop")
 	if curHp < 1:
-		print("YOU DIED")
+		print(" PROP : YOU DIED")	
+
+func takeDamageProp(damage,id):
+	rpc_id(id,"takeDamagePropRpc",damage)
+
 
 
 remote func _update_player_body(y, bodyScene, origin, rigidScene):


### PR DESCRIPTION
fixed label by separating the damage call on playerprops from the rpc damage call.